### PR TITLE
node.fs bindings in progress

### DIFF
--- a/src/js/io_js.re
+++ b/src/js/io_js.re
@@ -9,7 +9,7 @@ external node_buffer_alloc: int => Node_fs.buffer = "Buffer.alloc";
 external node_buffer_to_string:
   (Node_fs.buffer, string, int, int) => string = "toString";
 
-let open_: (string) => Promise.promise(fd) = filename =>
+let open_ = filename =>
   Promise.new_((~resolve) =>
     Node_fs.open_(~path=filename, ~flags="r", ~mode=438, (_error) => resolve));
 

--- a/src/js/node_fs.re
+++ b/src/js/node_fs.re
@@ -10,132 +10,122 @@ external node_buffer_to_string:
   (buffer, string, int, int) => string = "toString";
 
 [@bs.module "fs"]
-external access: (string, int, unit => unit) => unit = "access";
-
-/* 
-  This takes a optional field that I ommitted because we need to type it to a Js.t
-  https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_fs_appendfile_file_data_options_callback
-*/
-[@bs.module "fs"]
-external appendFile: (string, string, unit => unit) => unit = "appendFile";
+external access: (~path: string, ~mode: int, unit => unit) => unit = "access";
 
 [@bs.module "fs"]
-external chmod: (string, int, unit => unit) => unit = "chmod";
+external appendFile: (~file: string, ~data: string, ~options: string, unit => unit) => unit = "appendFile";
 
 [@bs.module "fs"]
-external chown: (string, int, int, unit => unit) => unit = "chown";
+external chmod: (~path: string, ~mode: int, unit => unit) => unit = "chmod";
 
 [@bs.module "fs"]
-external close: (int, (unit) => unit) => unit = "close";
+external chown: (~path: string, ~uid: int, ~gid: int, unit => unit) => unit = "chown";
 
 [@bs.module "fs"]
-external copyFile: (string, string, int, (unit) => unit) => unit = "copyFile";
+external close: (~fd: fd, unit => unit) => unit = "close";
 
 [@bs.module "fs"]
-external exists: (string, (bool) => unit) => unit = "exists";
+external copyFile: (~src: string, ~dest: string, ~flags: int, unit => unit) => unit = "copyFile";
 
 [@bs.module "fs"]
-external fchmod: (int, int, unit => unit) => unit = "fchmod";
+external exists: (~path: string, bool => unit) => unit = "exists";
 
 [@bs.module "fs"]
-external fchown: (int, int, int, unit => unit) => unit = "fchown";
+external fchmod: (~fd: fd, ~mode: int, unit => unit) => unit = "fchmod";
 
 [@bs.module "fs"]
-external fdatasync: (int, unit => unit) => unit = "fdatasync";
+external fchown: (~fd: fd, ~uid: int, ~gid: int, unit => unit) => unit = "fchown";
+
+[@bs.module "fs"]
+external fdatasync: (~fd: fd, unit => unit) => unit = "fdatasync";
 
 /*
   Needs to type second arg of callback to a Js.t in node.js - fs.Stats
   https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_class_fs_stats
 */
 [@bs.module "fs"]
-external fstat: (int, (unit, 'a) => unit) => unit = "fstat";
+external fstat: (~fd: fd, (unit, 'a) => unit) => unit = "fstat";
 
 [@bs.module "fs"]
-external fsync: (int, unit => unit) => unit = "fsync";
+external fsync: (~fd: fd, unit => unit) => unit = "fsync";
 
 [@bs.module "fs"]
-external ftruncate: (fd, int, unit => unit) => unit = "ftruncate";
+external ftruncate: (~fd: fd, ~len: int, unit => unit) => unit = "ftruncate";
 
 [@bs.module "fs"]
-external futimes: (int, int, int, unit => unit) => unit = "futimes";
+external futimes: (~fd: fd, ~atime: int, ~mtime: int, unit => unit) => unit = "futimes";
 
 [@bs.module "fs"]
-external lchmod: (string, int, unit => unit) => unit = "lchmod";
+external lchmod: (~path: string, ~mode: int, unit => unit) => unit = "lchmod";
 
 [@bs.module "fs"]
-external lchown: (string, int, int, unit => unit) => unit = "lchown";
+external lchown: (~path: string, ~uid: int, ~gid: int, unit => unit) => unit = "lchown";
 
 [@bs.module "fs"]
-external link: (string, string, unit => unit) => unit = "link";
+external link: (~existingPath: string, ~newPath: string, unit => unit) => unit = "link";
 
 [@bs.module "fs"]
-external lstat: (string, (unit, 'a) => unit) => unit = "lstat";
+external lstat: (~path: string, (unit, 'a) => unit) => unit = "lstat";
 
 [@bs.module "fs"]
-external mkdir: (string, int, unit => unit) => unit = "mkdir";
-/*
- Ommitted an optional argument that required typing a Js.t
- https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_fs_mkdtemp_prefix_options_callback
-*/
-[@bs.module "fs"]
-external mkdtemp: (string, (unit, string) => unit) => unit = "mkdir";
+external mkdir: (~path: string, ~mode: int, unit => unit) => unit = "mkdir";
 
 [@bs.module "fs"]
-external open_: (string, string, (unit, int) => unit) => unit = "open";
+external mkdtemp: (~prefix: string, ~options: string, (unit, string) => unit) => unit = "mkdir";
+
+[@bs.module "fs"]
+external open_: (~path: string, ~flags: string, ~mode: int, (unit, int) => unit) => unit = "open";
 
 [@bs.module "fs"]
 external read_:
-  (int, buffer, int, int, int, (unit, int, buffer) => unit) => unit = "read";
+  (~fd: fd, ~buffer: buffer, ~offset: int, ~length: int, ~position: int, (unit, int, buffer) => unit) => unit = "read";
 
 [@bs.module "fs"]
-external readdir: (string, (unit, array(string)) => unit) => unit = "readdir";
+external readdir: (~path: string, ~options: string, (unit, array(string)) => unit) => unit = "readdir";
 
 [@bs.module "fs"]
-external readFile: (string, string, (unit, string) => unit) => unit = "readFile";
+external readFile: (~path: string, ~options: string, (unit, string) => unit) => unit = "readFile";
 
 [@bs.module "fs"]
-external readLink: (string, string, (unit, string) => unit) => unit = "readLink";
+external readLink: (~path: string, ~options: string, (unit, string) => unit) => unit = "readLink";
 
 [@bs.module "fs"]
-external realpath: (string, string, (unit, string) => unit) => unit = "realpath";
+external realpath: (~path: string, ~options: string, (unit, string) => unit) => unit = "realpath";
 
 [@bs.module "fs"]
-external rename: (string, string, unit => unit) => unit = "rename";
+external rename: (~oldPath: string, ~newPath: string, unit => unit) => unit = "rename";
 
 [@bs.module "fs"]
-external rmdir: (string, (unit) => unit) => unit = "rmdir";
+external rmdir: (~path: string, (unit) => unit) => unit = "rmdir";
 
 [@bs.module "fs"]
-external stat: (string, string, (unit, 'a) => unit) => unit = "stat";
+external stat: (~path: string, (unit, 'a) => unit) => unit = "stat";
 
 [@bs.module "fs"]
-external symlink: (string, string, string, unit => unit) => unit = "symlink";
+external symlink: (~target: string, ~path: string, ~typ: string, unit => unit) => unit = "symlink";
 
 [@bs.module "fs"]
-external truncate: (string, int, unit => unit) => unit = "truncate";
+external truncate: (~path: string, ~len: int, unit => unit) => unit = "truncate";
 
 [@bs.module "fs"]
-external unlink: (string, unit => unit) => unit = "unlink";
+external unlink: (~path: string, unit => unit) => unit = "unlink";
 
 [@bs.module "fs"]
-external utimes: (string, float, float, unit => unit) => unit = "utimes";
+external utimes: (~path: string, ~atime: float, ~mtime: float, unit => unit) => unit = "utimes";
 
 [@bs.module "fs"]
-external write: (fd, string, int, int, int, (unit, int, string) => unit) => unit = "write";
+external write: (~fd: fd, ~str: string, ~position: int, ~encoding: string, (unit, int, string) => unit) => unit = "write";
 
 [@bs.module "fs"]
-external writeFile: (string, string, string, unit => unit) => unit = "writeFile";
+external writeFile: (~file: string, ~data: string, ~options: string, unit => unit) => unit = "writeFile";
 
-[@bs.module "fs"]
-external open_: (string, string, (unit, int) => unit) => unit = "open";
+/* let open_ = (path, callback) =>
+  open_(path, "r", 438, (_error, result) => callback(result)); */
 
-let open_ = (path, callback) =>
-  open_(path, "r", (_error, result) => callback(result));
-
-let read = (~fd, ~length, ~position, callback) => {
+/* let read = (~fd, ~length, ~position, callback) => {
   let buffer = node_buffer_alloc(length);
   read_(fd, buffer, 0, length, position, (_error, result, _buffer) => {
     let s = node_buffer_to_string(buffer, "utf8", 0, result);
     callback(s);
   });
-};
+}; */

--- a/src/js/node_fs.re
+++ b/src/js/node_fs.re
@@ -1,11 +1,5 @@
 type fd = int;
 
-[@bs.module "fs"]
-external node_fs_open_: (string, string, (unit, int) => unit) => unit = "open";
-
-let open_ = (path, callback) =>
-  node_fs_open_(path, "r", (_error, result) => callback(result));
-
 type buffer;
 
 [@bs.val]
@@ -16,12 +10,131 @@ external node_buffer_to_string:
   (buffer, string, int, int) => string = "toString";
 
 [@bs.module "fs"]
-external node_fs_read:
+external access: (string, int, unit => unit) => unit = "access";
+
+/* 
+  This takes a optional field that I ommitted because we need to type it to a Js.t
+  https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_fs_appendfile_file_data_options_callback
+*/
+[@bs.module "fs"]
+external appendFile: (string, string, unit => unit) => unit = "appendFile";
+
+[@bs.module "fs"]
+external chmod: (string, int, unit => unit) => unit = "chmod";
+
+[@bs.module "fs"]
+external chown: (string, int, int, unit => unit) => unit = "chown";
+
+[@bs.module "fs"]
+external close: (int, (unit) => unit) => unit = "close";
+
+[@bs.module "fs"]
+external copyFile: (string, string, int, (unit) => unit) => unit = "copyFile";
+
+[@bs.module "fs"]
+external exists: (string, (bool) => unit) => unit = "exists";
+
+[@bs.module "fs"]
+external fchmod: (int, int, (unit) => unit) => unit = "fchmod";
+
+[@bs.module "fs"]
+external fchown: (int, int, int, (unit) => unit) => unit = "fchown";
+
+[@bs.module "fs"]
+external fdatasync: (int, (unit) => unit) => unit = "fdatasync";
+
+/*
+  Needs to type second arg of callback to a Js.t in node.js - fs.Stats
+  https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_class_fs_stats
+*/
+[@bs.module "fs"]
+external fstat: (int, (unit, 'a) => unit) => unit = "fstat";
+
+[@bs.module "fs"]
+external fsync: (int, (unit) => unit) => unit = "fsync";
+
+[@bs.module "fs"]
+external ftruncate: (fd, int, (unit) => unit) => unit = "ftruncate";
+
+[@bs.module "fs"]
+external futimes: (int, int, int, (unit) => unit) => unit = "futimes";
+
+[@bs.module "fs"]
+external lchmod: (string, int, (unit) => unit) => unit = "lchmod";
+
+[@bs.module "fs"]
+external lchown: (string, int, int, (unit) => unit) => unit = "lchown";
+
+[@bs.module "fs"]
+external link: (string, string, (unit) => unit) => unit = "link";
+
+[@bs.module "fs"]
+external lstat: (string, (unit, 'a) => unit) => unit = "lstat";
+
+[@bs.module "fs"]
+external mkdir: (string, int, (unit) => unit) => unit = "mkdir";
+/*
+ Ommitted an optional argument that required typing a Js.t
+ https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_fs_mkdtemp_prefix_options_callback
+*/
+[@bs.module "fs"]
+external mkdtemp: (string, (unit, string) => unit) => unit = "mkdir";
+
+[@bs.module "fs"]
+external open_: (string, string, (unit, int) => unit) => unit = "open";
+
+[@bs.module "fs"]
+external read_:
   (int, buffer, int, int, int, (unit, int, buffer) => unit) => unit = "read";
+
+[@bs.module "fs"]
+external readdir: (string, (unit, array(string)) => unit) => unit = "readdir";
+
+[@bs.module "fs"]
+external readFile: (string, string, (unit, string) => unit) => unit = "readFile";
+
+[@bs.module "fs"]
+external readLink: (string, string, (unit, string) => unit) => unit = "readLink";
+
+[@bs.module "fs"]
+external realpath: (string, string, (unit, string) => unit) => unit = "realpath";
+
+[@bs.module "fs"]
+external rename: (string, string, (unit) => unit) => unit = "rename";
+
+[@bs.module "fs"]
+external rmdir: (string, (unit) => unit) => unit = "rmdir";
+
+[@bs.module "fs"]
+external stat: (string, string, (unit, 'a) => unit) => unit = "stat";
+
+[@bs.module "fs"]
+external symlink: (string, string, string, (unit) => unit) => unit = "symlink";
+
+[@bs.module "fs"]
+external truncate: (string, int, (unit) => unit) => unit = "truncate";
+
+[@bs.module "fs"]
+external unlink: (string, (unit) => unit) => unit = "unlink";
+
+[@bs.module "fs"]
+external utimes: (string, float, float, (unit) => unit) => unit = "utimes";
+
+[@bs.module "fs"]
+external write: (fd, string, int, int, int, (unit, int, string) => unit) => unit = "write";
+
+[@bs.module "fs"]
+external writeFile: (string, string, string, (unit) => unit) => unit = "writeFile";
+
+[@bs.module "fs"]
+external open_: (string, string, (unit, int) => unit) => unit = "open";
+
+let open_ = (path, callback) =>
+  open_(path, "r", (_error, result) => callback(result));
 
 let read = (~fd, ~length, ~position, callback) => {
   let buffer = node_buffer_alloc(length);
-  node_fs_read(fd, buffer, 0, length, position, (_error, result, _buffer) => {
+  read_(fd, buffer, 0, length, position, (_error, result, _buffer) => {
     let s = node_buffer_to_string(buffer, "utf8", 0, result);
     callback(s);
   });

--- a/src/js/node_fs.re
+++ b/src/js/node_fs.re
@@ -35,13 +35,13 @@ external copyFile: (string, string, int, (unit) => unit) => unit = "copyFile";
 external exists: (string, (bool) => unit) => unit = "exists";
 
 [@bs.module "fs"]
-external fchmod: (int, int, (unit) => unit) => unit = "fchmod";
+external fchmod: (int, int, unit => unit) => unit = "fchmod";
 
 [@bs.module "fs"]
-external fchown: (int, int, int, (unit) => unit) => unit = "fchown";
+external fchown: (int, int, int, unit => unit) => unit = "fchown";
 
 [@bs.module "fs"]
-external fdatasync: (int, (unit) => unit) => unit = "fdatasync";
+external fdatasync: (int, unit => unit) => unit = "fdatasync";
 
 /*
   Needs to type second arg of callback to a Js.t in node.js - fs.Stats
@@ -51,28 +51,28 @@ external fdatasync: (int, (unit) => unit) => unit = "fdatasync";
 external fstat: (int, (unit, 'a) => unit) => unit = "fstat";
 
 [@bs.module "fs"]
-external fsync: (int, (unit) => unit) => unit = "fsync";
+external fsync: (int, unit => unit) => unit = "fsync";
 
 [@bs.module "fs"]
-external ftruncate: (fd, int, (unit) => unit) => unit = "ftruncate";
+external ftruncate: (fd, int, unit => unit) => unit = "ftruncate";
 
 [@bs.module "fs"]
-external futimes: (int, int, int, (unit) => unit) => unit = "futimes";
+external futimes: (int, int, int, unit => unit) => unit = "futimes";
 
 [@bs.module "fs"]
-external lchmod: (string, int, (unit) => unit) => unit = "lchmod";
+external lchmod: (string, int, unit => unit) => unit = "lchmod";
 
 [@bs.module "fs"]
-external lchown: (string, int, int, (unit) => unit) => unit = "lchown";
+external lchown: (string, int, int, unit => unit) => unit = "lchown";
 
 [@bs.module "fs"]
-external link: (string, string, (unit) => unit) => unit = "link";
+external link: (string, string, unit => unit) => unit = "link";
 
 [@bs.module "fs"]
 external lstat: (string, (unit, 'a) => unit) => unit = "lstat";
 
 [@bs.module "fs"]
-external mkdir: (string, int, (unit) => unit) => unit = "mkdir";
+external mkdir: (string, int, unit => unit) => unit = "mkdir";
 /*
  Ommitted an optional argument that required typing a Js.t
  https://nodejs.org/dist/latest-v9.x/docs/api/fs.html#fs_fs_mkdtemp_prefix_options_callback
@@ -100,7 +100,7 @@ external readLink: (string, string, (unit, string) => unit) => unit = "readLink"
 external realpath: (string, string, (unit, string) => unit) => unit = "realpath";
 
 [@bs.module "fs"]
-external rename: (string, string, (unit) => unit) => unit = "rename";
+external rename: (string, string, unit => unit) => unit = "rename";
 
 [@bs.module "fs"]
 external rmdir: (string, (unit) => unit) => unit = "rmdir";
@@ -109,22 +109,22 @@ external rmdir: (string, (unit) => unit) => unit = "rmdir";
 external stat: (string, string, (unit, 'a) => unit) => unit = "stat";
 
 [@bs.module "fs"]
-external symlink: (string, string, string, (unit) => unit) => unit = "symlink";
+external symlink: (string, string, string, unit => unit) => unit = "symlink";
 
 [@bs.module "fs"]
-external truncate: (string, int, (unit) => unit) => unit = "truncate";
+external truncate: (string, int, unit => unit) => unit = "truncate";
 
 [@bs.module "fs"]
-external unlink: (string, (unit) => unit) => unit = "unlink";
+external unlink: (string, unit => unit) => unit = "unlink";
 
 [@bs.module "fs"]
-external utimes: (string, float, float, (unit) => unit) => unit = "utimes";
+external utimes: (string, float, float, unit => unit) => unit = "utimes";
 
 [@bs.module "fs"]
 external write: (fd, string, int, int, int, (unit, int, string) => unit) => unit = "write";
 
 [@bs.module "fs"]
-external writeFile: (string, string, string, (unit) => unit) => unit = "writeFile";
+external writeFile: (string, string, string, unit => unit) => unit = "writeFile";
 
 [@bs.module "fs"]
 external open_: (string, string, (unit, int) => unit) => unit = "open";

--- a/src/js/node_fs.re
+++ b/src/js/node_fs.re
@@ -2,13 +2,6 @@ type fd = int;
 
 type buffer;
 
-[@bs.val]
-external node_buffer_alloc: int => buffer = "Buffer.alloc";
-
-[@bs.send]
-external node_buffer_to_string:
-  (buffer, string, int, int) => string = "toString";
-
 [@bs.module "fs"]
 external access: (~path: string, ~mode: int, unit => unit) => unit = "access";
 

--- a/src/js/node_fs.re
+++ b/src/js/node_fs.re
@@ -118,14 +118,3 @@ external write: (~fd: fd, ~str: string, ~position: int, ~encoding: string, (unit
 
 [@bs.module "fs"]
 external writeFile: (~file: string, ~data: string, ~options: string, unit => unit) => unit = "writeFile";
-
-/* let open_ = (path, callback) =>
-  open_(path, "r", 438, (_error, result) => callback(result)); */
-
-/* let read = (~fd, ~length, ~position, callback) => {
-  let buffer = node_buffer_alloc(length);
-  read_(fd, buffer, 0, length, position, (_error, result, _buffer) => {
-    let s = node_buffer_to_string(buffer, "utf8", 0, result);
-    callback(s);
-  });
-}; */

--- a/src/js/node_fs.rei
+++ b/src/js/node_fs.rei
@@ -1,4 +1,73 @@
 type fd;
 
-let open_: (string, int => unit) => unit;
-let read: (~fd: int, ~length: int, ~position: int, string => unit) => unit;
+type buffer;
+
+let access: (~path: string, ~mode: int, unit => unit) => unit;
+
+let appendFile: (~file: string, ~data: string, ~options: string, unit => unit) => unit;
+
+let chmod: (~path: string, ~mode: int, unit => unit) => unit;
+
+let chown: (~path: string, ~uid: int, ~gid: int, unit => unit) => unit;
+
+let close: (~fd: fd, unit => unit) => unit;
+
+let copyFile: (~src: string, ~dest: string, ~flags: int, unit => unit) => unit;
+
+let exists: (~path: string, bool => unit) => unit;
+
+let fchmod: (~fd: fd, ~mode: int, unit => unit) => unit;
+
+let fchown: (~fd: fd, ~uid: int, ~gid: int, unit => unit) => unit;
+
+let fdatasync: (~fd: fd, unit => unit) => unit;
+
+let fstat: (~fd: fd, (unit, 'a) => unit) => unit;
+
+let fsync: (~fd: fd, unit => unit) => unit;
+
+let ftruncate: (~fd: fd, ~len: int, unit => unit) => unit;
+
+let futimes: (~fd: fd, ~atime: int, ~mtime: int, unit => unit) => unit;
+
+let lchmod: (~path: string, ~mode: int, unit => unit) => unit;
+
+let lchown: (~path: string, ~uid: int, ~gid: int, unit => unit) => unit;
+
+let link: (~existingPath: string, ~newPath: string, unit => unit) => unit;
+
+let lstat: (~path: string, (unit, 'a) => unit) => unit;
+
+let mkdir: (~path: string, ~mode: int, unit => unit) => unit;
+
+let mkdtemp: (~prefix: string, ~options: string, (unit, string) => unit) => unit;
+
+let open_: (~path: string, ~flags: string, ~mode: int, (unit, int) => unit) => unit;
+
+let read_: (~fd: fd, ~buffer: buffer, ~offset: int, ~length: int, ~position: int, (unit, int, buffer) => unit) => unit;
+
+let readdir: (~path: string, ~options: string, (unit, array(string)) => unit) => unit;
+
+let readFile: (~path: string, ~options: string, (unit, string) => unit) => unit;
+
+let readLink: (~path: string, ~options: string, (unit, string) => unit) => unit;
+
+let realpath: (~path: string, ~options: string, (unit, string) => unit) => unit;
+
+let rename: (~oldPath: string, ~newPath: string, unit => unit) => unit;
+
+let rmdir: (~path: string, (unit) => unit) => unit;
+
+let stat: (~path: string, (unit, 'a) => unit) => unit;
+
+let symlink: (~target: string, ~path: string, ~typ: string, unit => unit) => unit;
+
+let truncate: (~path: string, ~len: int, unit => unit) => unit;
+
+let unlink: (~path: string, unit => unit) => unit;
+
+let utimes: (~path: string, ~atime: float, ~mtime: float, unit => unit) => unit;
+
+let write: (~fd: fd, ~str: string, ~position: int, ~encoding: string, (unit, int, string) => unit) => unit;
+
+let writeFile: (~file: string, ~data: string, ~options: string, unit => unit) => unit;

--- a/src/js/node_fs.rei
+++ b/src/js/node_fs.rei
@@ -42,7 +42,7 @@ let mkdir: (~path: string, ~mode: int, unit => unit) => unit;
 
 let mkdtemp: (~prefix: string, ~options: string, (unit, string) => unit) => unit;
 
-let open_: (~path: string, ~flags: string, ~mode: int, (unit, int) => unit) => unit;
+let open_: (~path: string, ~flags: string, ~mode: int, (unit, fd) => unit) => unit;
 
 let read_: (~fd: fd, ~buffer: buffer, ~offset: int, ~length: int, ~position: int, (unit, int, buffer) => unit) => unit;
 


### PR DESCRIPTION
Hey so these include some in progress bindings to node filesystem module. I've gone ahead and omitted arguments to a few functions that require a `Js.t` as an argument. 

So some things moving forward:
- How to get rid warnings of unused value for the bindings (odd because I don't get these in a project I have)
- How should we type `Js.t`'s from functions? Some functions have same `Js.t`, others don't.
- How should we type classes from node.fs?
- Do we need a `.rei` file if these are just going to be bindings?
- Add labels to arguments with default values for node.fs optional arguments?